### PR TITLE
SECURITY-8: Add docker compose for superset and postgres

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,35 @@
+# This docker-compose is for developer convenience, not for running in production.
+
+volumes:
+  postgres_data:
+
+services:
+
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: superset
+      POSTGRES_PASSWORD: superset
+      POSTGRES_DB: superset_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  superset:
+    image: apache/superset:5.0.0-dev
+    depends_on:
+      - postgres
+    environment:
+      SUPERSET_CONFIG_PATH: /opt/superset_config.py
+      SUPERSET_ADMIN_USERNAME: admin
+      SUPERSET_ADMIN_PASSWORD: admin
+      SUPERSET_ADMIN_FIRST_NAME: Admin
+      SUPERSET_ADMIN_LAST_NAME: User
+      SUPERSET_ADMIN_EMAIL: admin@example.com
+    ports:
+      - "8088:8088"
+    entrypoint: ["/bin/bash", "/opt/superset-entrypoint.sh"]
+    volumes:
+      - ./docker-compose/superset-entrypoint.sh:/opt/superset-entrypoint.sh:ro
+      - ./docker-compose/superset_config.py:/opt/superset_config.py

--- a/docker-compose/superset-entrypoint.sh
+++ b/docker-compose/superset-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+echo
+echo "*** Upgrading the superset metadata DB ***"
+superset db upgrade
+
+echo
+echo "*** Creating superset admin user ***"
+superset fab create-admin \
+  --username "${SUPERSET_ADMIN_USERNAME:-admin}" \
+  --firstname "${SUPERSET_ADMIN_FIRST_NAME:-Admin}" \
+  --lastname "${SUPERSET_ADMIN_LAST_NAME:-User}" \
+  --email "${SUPERSET_ADMIN_EMAIL:-admin@example.com}" \
+  --password "${SUPERSET_ADMIN_PASSWORD:-admin}" || true
+
+echo
+echo "*** Initializing superset ***"
+superset init
+
+echo
+echo "*** Running superset ***"
+exec superset run -h 0.0.0.0 -p 8088 --with-threads

--- a/docker-compose/superset_config.py
+++ b/docker-compose/superset_config.py
@@ -1,0 +1,5 @@
+# required for startup
+SECRET_KEY = "ThisIsAFakeKeyForLocalTestingDoNotUseItInProductionOrYoureADoof"
+
+# These are set in the docker-compose.yaml file
+SQLALCHEMY_DATABASE_URI = "postgresql://superset:superset@postgres:5432/superset_db"


### PR DESCRIPTION
* superset seems to require the postgres URI in superset_config.py in order to connect
  * An env var failed
* Tested by inserting some sample data into postgres and visualizing it with superset