### PR TITLE
Switch to a canonical branch name

### DIFF
--- a/superset/README.md
+++ b/superset/README.md
@@ -1,6 +1,6 @@
-## Main Table Query
+## Org / repo joining
 
-The main table query combines org_user and repo into a single "repository" column using:
+The queries combine org_user and repo into a single "repository" column using:
 
 ```sql
 org_user || '/' || repo AS repository
@@ -24,10 +24,15 @@ The main table includes two security columns that aggregate data from multiple s
 ## Dashboard Layout
 
 * Column 1
-    * Text noting that 0 in a cell could mean that the check isn't working
+    * Text:
+        ```
+        * Note that 0 may mean "no issues" or "check isn't working"
+        * Graphs are not meaningful until a repo is selected in the main table
+        ```
         * E.g. for dependabot PRs or security alerts
     * Main table
-        * Has a native multiselect filter on branch
+        * No branch column
+            * Could add a "real branch" column, YAGNI
         * Color coding
             * Coverage
                 * Green for > 80
@@ -46,10 +51,13 @@ The main table includes two security columns that aggregate data from multiple s
     * For all 3 charts:
         * Metrics are renamed to Critical, High, Medium, Low
             * See JSON color configuration below
-    * For the last 2 charts:
-        * Has a native single select filter on branch requiring a default value
 
-General notes:
+## Dashboard General Configuration
+
+* Dashboard has a native single select filter on cnclbrnch that
+    * requires a value
+    * has a default of main
+    * applies to the main table and the code and trivy alerts tables
 * Dimension labels were sorted via category name ascending
 * For all line charts and scatter plots, values were averaged over each day
 

--- a/superset/detail_table_queries.md
+++ b/superset/detail_table_queries.md
@@ -1,34 +1,42 @@
 Test:
 
-```
-SELECT 
-    timestamp,
-    org_user || '/' || repo AS repository,
-    branch,
+```sql
+SELECT
+    ts.timestamp,
+    ts.org_user || '/' || ts.repo AS repository,
+    CASE
+        WHEN ts.branch = m.main_branch THEN 'main'
+        WHEN ts.branch = m.dev_branch THEN 'develop'
+    END AS cnclbrnch,
     CASE
         WHEN success THEN '✅ Pass'
         ELSE '❌ Fail'
     END AS status
-FROM test_status
-ORDER BY timestamp DESC
+FROM test_status ts
+JOIN repo_metadata m ON ts.org_user = m.org_user AND ts.repo = m.repo
+ORDER BY ts.timestamp DESC
 ```
 
 Coverage:
 
-```
-SELECT 
-    timestamp,
-    org_user || '/' || repo AS repository,
-    branch,
-    coverage
-FROM coverage_history
-ORDER BY timestamp
+```sql
+SELECT
+    ch.timestamp,
+    ch.org_user || '/' || ch.repo AS repository,
+    CASE
+        WHEN ch.branch = m.main_branch THEN 'main'
+        WHEN ch.branch = m.dev_branch THEN 'develop'
+    END AS cnclbrnch,
+    ch.coverage
+FROM coverage_history ch
+JOIN repo_metadata m ON ch.org_user = m.org_user AND ch.repo = m.repo
+ORDER BY ch.timestamp
 ```
 
 Dependabot:
 
-```
-SELECT 
+```sql
+SELECT
     timestamp,
     org_user || '/' || repo AS repository,
     dependencies
@@ -38,8 +46,8 @@ ORDER BY timestamp
 
 Dependabot alerts:
 
-```
-SELECT 
+```sql
+SELECT
     timestamp,
     org_user || '/' || repo AS repository,
     critical,
@@ -52,30 +60,38 @@ ORDER BY timestamp
 
 Code scanning alerts:
 
-```
-SELECT 
-    timestamp,
-    org_user || '/' || repo AS repository,
-    branch,
-    critical,
-    high,
-    medium,
-    low
-FROM code_scanning_alerts
-ORDER BY timestamp
+```sql
+SELECT
+    csa.timestamp,
+    csa.org_user || '/' || csa.repo AS repository,
+    CASE
+        WHEN csa.branch = m.main_branch THEN 'main'
+        WHEN csa.branch = m.dev_branch THEN 'develop'
+    END AS cnclbrnch,
+    csa.critical,
+    csa.high,
+    csa.medium,
+    csa.low
+FROM code_scanning_alerts csa
+JOIN repo_metadata m ON csa.org_user = m.org_user AND csa.repo = m.repo
+ORDER BY csa.timestamp
 ```
 
 Trivy alerts:
 
-```
-SELECT 
-    timestamp,
-    org_user || '/' || repo AS repository,
-    branch,
-    critical,
-    high,
-    medium,
-    low
-FROM trivy_scans
-ORDER BY timestamp
+```sql
+SELECT
+    t.timestamp,
+    t.org_user || '/' || t.repo AS repository,
+    CASE
+        WHEN t.branch = m.main_branch THEN 'main'
+        WHEN t.branch = m.dev_branch THEN 'develop'
+    END AS cnclbrnch,
+    t.critical,
+    t.high,
+    t.medium,
+    t.low
+FROM trivy_scans t
+JOIN repo_metadata m ON t.org_user = m.org_user AND t.repo = m.repo
+ORDER BY t.timestamp
 ```

--- a/superset/main_table_query.md
+++ b/superset/main_table_query.md
@@ -1,9 +1,13 @@
+```sql
 WITH repos_expanded AS (
     -- Create one row per repo per branch (main and dev)
+    -- branch is the actual branch name used for JOINs
+    -- cnclbrnch is the canonical name shown in the dashboard (always main/develop)
     SELECT
         org_user,
         repo,
         main_branch AS branch,
+        'main' AS cnclbrnch,
         1 AS branch_order  -- main branch first
     FROM repo_metadata
 
@@ -13,6 +17,7 @@ WITH repos_expanded AS (
         org_user,
         repo,
         dev_branch AS branch,
+        'develop' AS cnclbrnch,
         2 AS branch_order  -- dev branch second
     FROM repo_metadata
 ),
@@ -86,7 +91,7 @@ latest_trivy AS (
 
 SELECT
     r.org_user || '/' || r.repo AS repository,
-    r.branch,
+    r.cnclbrnch,
     ts.test_status,
     c.coverage,
     d.dependencies,
@@ -113,3 +118,4 @@ LEFT JOIN latest_trivy t ON r.org_user = t.org_user
     AND r.repo = t.repo
     AND r.branch = t.branch
 ORDER BY r.org_user, r.repo, r.branch_order;
+```


### PR DESCRIPTION
Easier if the main / master branch is always named "main" in the dashboard